### PR TITLE
feat: MoFa Notebook framework (M1)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,8 @@ import { ChatLayout } from "./layouts/chat-layout";
 import { Thread } from "./components/thread";
 import { ThinkingIndicator } from "./components/thinking-indicator";
 import { ToolProgressIndicator } from "./components/tool-progress-indicator";
+import { NotebookListPage } from "./notebook/pages/notebook-list";
+import { NotebookDetailPage } from "./notebook/pages/notebook-detail";
 import {
   ShellToolUI,
   ReadFileToolUI,
@@ -26,6 +28,24 @@ export function App() {
         <Routes>
           <Route path="/login" element={<LoginPage />} />
           <Route element={<AuthGuard />}>
+            {/* Notebook routes */}
+            <Route
+              path="/notebooks"
+              element={
+                <ChatLayout>
+                  <NotebookListPage />
+                </ChatLayout>
+              }
+            />
+            <Route
+              path="/notebooks/:id"
+              element={
+                <ChatLayout>
+                  <NotebookDetailPage />
+                </ChatLayout>
+              }
+            />
+            {/* Chat route (default) */}
             <Route
               path="/*"
               element={

--- a/src/layouts/chat-layout.tsx
+++ b/src/layouts/chat-layout.tsx
@@ -1,15 +1,20 @@
 import type { ReactNode } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
 import { useAuth } from "@/auth/auth-context";
 import { useOctosStatus } from "@/hooks/use-octos-status";
 import { useTheme } from "@/hooks/use-theme";
 import { CostBar } from "@/components/cost-bar";
 import { SessionList } from "@/components/session-list";
-import { LogOut, MessageSquare, Sun, Moon } from "lucide-react";
+import { LogOut, MessageSquare, BookOpen, Sun, Moon } from "lucide-react";
 
 export function ChatLayout({ children }: { children: ReactNode }) {
   const { user, logout } = useAuth();
   const status = useOctosStatus();
   const { theme, toggleTheme } = useTheme();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const isNotebookRoute = location.pathname.startsWith("/notebooks");
 
   return (
     <div className="flex h-screen bg-surface-dark">
@@ -17,8 +22,8 @@ export function ChatLayout({ children }: { children: ReactNode }) {
       <aside className="flex w-64 flex-col border-r border-border bg-surface">
         {/* Header */}
         <div className="flex items-center gap-2 border-b border-border px-4 py-3">
-          <MessageSquare size={20} className="text-accent" />
-          <span className="font-semibold text-text-strong">octos</span>
+          <BookOpen size={20} className="text-accent" />
+          <span className="font-semibold text-text-strong">MoFa</span>
           <button
             onClick={toggleTheme}
             className="ml-auto rounded-lg p-1.5 text-muted hover:bg-surface-light hover:text-accent transition"
@@ -28,8 +33,35 @@ export function ChatLayout({ children }: { children: ReactNode }) {
           </button>
         </div>
 
-        {/* Session list */}
-        <SessionList />
+        {/* Nav tabs */}
+        <div className="flex border-b border-border">
+          <button
+            onClick={() => navigate("/notebooks")}
+            className={`flex flex-1 items-center justify-center gap-1.5 py-2.5 text-xs font-medium transition ${
+              isNotebookRoute
+                ? "border-b-2 border-accent text-accent"
+                : "text-muted hover:text-text"
+            }`}
+          >
+            <BookOpen size={14} />
+            Notebooks
+          </button>
+          <button
+            onClick={() => navigate("/")}
+            className={`flex flex-1 items-center justify-center gap-1.5 py-2.5 text-xs font-medium transition ${
+              !isNotebookRoute
+                ? "border-b-2 border-accent text-accent"
+                : "text-muted hover:text-text"
+            }`}
+          >
+            <MessageSquare size={14} />
+            Chat
+          </button>
+        </div>
+
+        {/* Session list (only in chat mode) */}
+        {!isNotebookRoute && <SessionList />}
+        {isNotebookRoute && <div className="flex-1" />}
 
         {/* Footer */}
         <div className="border-t border-border p-3">
@@ -56,7 +88,7 @@ export function ChatLayout({ children }: { children: ReactNode }) {
 
       {/* Main */}
       <main className="flex flex-1 min-w-0 flex-col min-h-0">
-        <CostBar model={status?.model} provider={status?.provider} />
+        {!isNotebookRoute && <CostBar model={status?.model} provider={status?.provider} />}
         <div className="flex-1 min-h-0 overflow-hidden">{children}</div>
       </main>
     </div>

--- a/src/notebook/api/notebooks.ts
+++ b/src/notebook/api/notebooks.ts
@@ -1,0 +1,56 @@
+import { request } from "@/api/client";
+import type { Notebook } from "./types";
+
+// NOTE: These APIs are stubs for now — the backend endpoints don't exist yet.
+// They use localStorage as a temporary store until the backend is ready.
+
+const STORAGE_KEY = "mofa_notebooks";
+
+function loadNotebooks(): Notebook[] {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) || "[]");
+  } catch {
+    return [];
+  }
+}
+
+function saveNotebooks(notebooks: Notebook[]) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(notebooks));
+}
+
+export async function listNotebooks(): Promise<Notebook[]> {
+  // TODO: replace with `request<Notebook[]>("/api/notebooks")` when backend is ready
+  return loadNotebooks();
+}
+
+export async function createNotebook(title: string, description = ""): Promise<Notebook> {
+  // TODO: replace with `request<Notebook>("/api/notebooks", { method: "POST", body: ... })`
+  const nb: Notebook = {
+    id: `nb-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+    title,
+    description,
+    source_count: 0,
+    note_count: 0,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  };
+  const all = loadNotebooks();
+  all.unshift(nb);
+  saveNotebooks(all);
+  return nb;
+}
+
+export async function deleteNotebook(id: string): Promise<void> {
+  // TODO: replace with `request("/api/notebooks/${id}", { method: "DELETE" })`
+  const all = loadNotebooks().filter((n) => n.id !== id);
+  saveNotebooks(all);
+}
+
+export async function updateNotebook(id: string, updates: Partial<Pick<Notebook, "title" | "description">>): Promise<Notebook> {
+  const all = loadNotebooks();
+  const idx = all.findIndex((n) => n.id === id);
+  if (idx === -1) throw new Error("Notebook not found");
+  all[idx] = { ...all[idx], ...updates, updated_at: new Date().toISOString() };
+  saveNotebooks(all);
+  return all[idx];
+}

--- a/src/notebook/api/types.ts
+++ b/src/notebook/api/types.ts
@@ -1,0 +1,51 @@
+// Notebook data types
+
+export interface Notebook {
+  id: string;
+  title: string;
+  description: string;
+  cover_image?: string;
+  source_count: number;
+  note_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Source {
+  id: string;
+  notebook_id: string;
+  type: "pdf" | "url" | "text" | "docx" | "pptx" | "image";
+  filename: string;
+  status: "uploading" | "parsing" | "indexing" | "ready" | "error";
+  error_message?: string;
+  chunk_count: number;
+  created_at: string;
+}
+
+export interface SourceChunk {
+  id: string;
+  source_id: string;
+  content: string;
+  start_offset: number;
+  end_offset: number;
+}
+
+export interface Note {
+  id: string;
+  notebook_id: string;
+  content: string;
+  source_refs: string[];
+  created_from: "manual" | "chat_reply";
+  created_at: string;
+  updated_at: string;
+}
+
+export interface StudioOutput {
+  id: string;
+  notebook_id: string;
+  type: "slides" | "quiz" | "flashcards" | "mindmap" | "audio" | "infographic" | "comic" | "report" | "research";
+  status: "generating" | "done" | "error";
+  file_path?: string;
+  config?: Record<string, unknown>;
+  created_at: string;
+}

--- a/src/notebook/pages/notebook-detail.tsx
+++ b/src/notebook/pages/notebook-detail.tsx
@@ -1,0 +1,141 @@
+import { useState, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { ArrowLeft, FileText, MessageSquare, StickyNote, Wand2, Upload, Plus } from "lucide-react";
+import { listNotebooks } from "../api/notebooks";
+import type { Notebook } from "../api/types";
+
+type Tab = "sources" | "chat" | "notes" | "studio";
+
+export function NotebookDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const [notebook, setNotebook] = useState<Notebook | null>(null);
+  const [activeTab, setActiveTab] = useState<Tab>("chat");
+
+  useEffect(() => {
+    listNotebooks().then((nbs) => {
+      const nb = nbs.find((n) => n.id === id);
+      if (nb) setNotebook(nb);
+      else navigate("/notebooks");
+    });
+  }, [id, navigate]);
+
+  if (!notebook) return null;
+
+  const tabs: { key: Tab; label: string; icon: React.ReactNode }[] = [
+    { key: "sources", label: "Sources", icon: <FileText size={16} /> },
+    { key: "chat", label: "Chat", icon: <MessageSquare size={16} /> },
+    { key: "notes", label: "Notes", icon: <StickyNote size={16} /> },
+    { key: "studio", label: "Studio", icon: <Wand2 size={16} /> },
+  ];
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Header */}
+      <div className="flex items-center gap-3 border-b border-border px-4 py-3">
+        <button
+          onClick={() => navigate("/notebooks")}
+          className="rounded-lg p-1.5 text-muted hover:bg-surface-light hover:text-text transition"
+        >
+          <ArrowLeft size={18} />
+        </button>
+        <h1 className="text-lg font-semibold text-text-strong">{notebook.title}</h1>
+
+        {/* Tabs */}
+        <div className="ml-auto flex gap-1">
+          {tabs.map((t) => (
+            <button
+              key={t.key}
+              onClick={() => setActiveTab(t.key)}
+              className={`flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm transition ${
+                activeTab === t.key
+                  ? "bg-accent/15 text-accent"
+                  : "text-muted hover:bg-surface-light hover:text-text"
+              }`}
+            >
+              {t.icon}
+              {t.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 min-h-0 overflow-hidden">
+        {activeTab === "sources" && <SourcesPanel notebookId={notebook.id} />}
+        {activeTab === "chat" && <ChatPanel notebookId={notebook.id} />}
+        {activeTab === "notes" && <NotesPanel notebookId={notebook.id} />}
+        {activeTab === "studio" && <StudioPanel notebookId={notebook.id} />}
+      </div>
+    </div>
+  );
+}
+
+// --- Placeholder panels (will be implemented in subsequent milestones) ---
+
+function SourcesPanel({ notebookId }: { notebookId: string }) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center text-muted">
+      <Upload size={48} className="mb-4 opacity-30" />
+      <p className="text-lg">No sources yet</p>
+      <p className="mb-4 text-sm">Upload PDFs, paste URLs, or add text to get started</p>
+      <button className="flex items-center gap-2 rounded-lg bg-accent px-4 py-2 text-sm text-white hover:bg-accent/90 transition">
+        <Plus size={16} />
+        Add Source
+      </button>
+    </div>
+  );
+}
+
+function ChatPanel({ notebookId }: { notebookId: string }) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center text-muted">
+      <MessageSquare size={48} className="mb-4 opacity-30" />
+      <p className="text-lg">Chat with your sources</p>
+      <p className="text-sm">Add sources first, then ask questions about them</p>
+    </div>
+  );
+}
+
+function NotesPanel({ notebookId }: { notebookId: string }) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center text-muted">
+      <StickyNote size={48} className="mb-4 opacity-30" />
+      <p className="text-lg">No notes yet</p>
+      <p className="text-sm">Save chat replies or create notes manually</p>
+    </div>
+  );
+}
+
+function StudioPanel({ notebookId }: { notebookId: string }) {
+  const outputs = [
+    { key: "slides", label: "Slides", emoji: "📊", desc: "Generate PPT courseware" },
+    { key: "quiz", label: "Quiz", emoji: "❓", desc: "Generate test questions" },
+    { key: "flashcards", label: "Flashcards", emoji: "🃏", desc: "Generate study cards" },
+    { key: "mindmap", label: "Mind Map", emoji: "🧠", desc: "Visualize key concepts" },
+    { key: "audio", label: "Audio", emoji: "🎙️", desc: "Generate podcast overview" },
+    { key: "infographic", label: "Infographic", emoji: "📈", desc: "Generate visual summary" },
+    { key: "comic", label: "Comic", emoji: "💬", desc: "Explain with comics" },
+    { key: "report", label: "Report", emoji: "📄", desc: "Generate Word/Excel report" },
+    { key: "research", label: "Research", emoji: "🔬", desc: "Deep research from web" },
+  ];
+
+  return (
+    <div className="p-6">
+      <h2 className="mb-4 text-lg font-semibold text-text-strong">Studio</h2>
+      <p className="mb-6 text-sm text-muted">Generate courseware and study materials from your sources</p>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+        {outputs.map((o) => (
+          <button
+            key={o.key}
+            className="flex flex-col items-center gap-2 rounded-xl border border-border bg-surface p-4 text-center transition hover:border-accent/50 hover:shadow-lg hover:shadow-accent/5"
+          >
+            <span className="text-2xl">{o.emoji}</span>
+            <span className="text-sm font-medium text-text-strong">{o.label}</span>
+            <span className="text-xs text-muted">{o.desc}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/notebook/pages/notebook-list.tsx
+++ b/src/notebook/pages/notebook-list.tsx
@@ -1,0 +1,174 @@
+import { useState, useEffect, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { Plus, BookOpen, Trash2, Search, FileText, Clock } from "lucide-react";
+import { listNotebooks, createNotebook, deleteNotebook } from "../api/notebooks";
+import type { Notebook } from "../api/types";
+
+export function NotebookListPage() {
+  const navigate = useNavigate();
+  const [notebooks, setNotebooks] = useState<Notebook[]>([]);
+  const [search, setSearch] = useState("");
+  const [creating, setCreating] = useState(false);
+  const [newTitle, setNewTitle] = useState("");
+
+  const load = useCallback(async () => {
+    const list = await listNotebooks();
+    setNotebooks(list);
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleCreate = async () => {
+    if (!newTitle.trim()) return;
+    const nb = await createNotebook(newTitle.trim());
+    setNewTitle("");
+    setCreating(false);
+    navigate(`/notebooks/${nb.id}`);
+  };
+
+  const handleDelete = async (e: React.MouseEvent, id: string) => {
+    e.stopPropagation();
+    await deleteNotebook(id);
+    load();
+  };
+
+  const filtered = notebooks.filter(
+    (n) =>
+      n.title.toLowerCase().includes(search.toLowerCase()) ||
+      n.description.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-border px-6 py-4">
+        <div>
+          <h1 className="text-xl font-semibold text-text-strong">MoFa Notebook</h1>
+          <p className="text-sm text-muted">Upload sources, chat with AI, generate courseware</p>
+        </div>
+        <button
+          onClick={() => setCreating(true)}
+          className="flex items-center gap-2 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 transition"
+        >
+          <Plus size={16} />
+          New Notebook
+        </button>
+      </div>
+
+      {/* Search */}
+      <div className="px-6 py-3">
+        <div className="relative">
+          <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-muted" />
+          <input
+            type="text"
+            placeholder="Search notebooks..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full rounded-lg border border-border bg-surface py-2 pl-10 pr-4 text-sm text-text placeholder:text-muted focus:border-accent focus:outline-none"
+          />
+        </div>
+      </div>
+
+      {/* Create dialog */}
+      {creating && (
+        <div className="mx-6 mb-3 rounded-lg border border-accent/30 bg-surface-light p-4">
+          <input
+            autoFocus
+            type="text"
+            placeholder="Notebook title..."
+            value={newTitle}
+            onChange={(e) => setNewTitle(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleCreate();
+              if (e.key === "Escape") setCreating(false);
+            }}
+            className="w-full rounded border border-border bg-surface px-3 py-2 text-sm text-text placeholder:text-muted focus:border-accent focus:outline-none"
+          />
+          <div className="mt-2 flex gap-2 justify-end">
+            <button
+              onClick={() => setCreating(false)}
+              className="rounded px-3 py-1 text-sm text-muted hover:text-text"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleCreate}
+              disabled={!newTitle.trim()}
+              className="rounded bg-accent px-3 py-1 text-sm text-white hover:bg-accent/90 disabled:opacity-50"
+            >
+              Create
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Notebook grid */}
+      <div className="flex-1 overflow-y-auto px-6 pb-6">
+        {filtered.length === 0 ? (
+          <div className="flex h-64 flex-col items-center justify-center text-muted">
+            <BookOpen size={48} className="mb-4 opacity-30" />
+            <p className="text-lg">
+              {notebooks.length === 0
+                ? "No notebooks yet"
+                : "No matching notebooks"}
+            </p>
+            <p className="text-sm">
+              {notebooks.length === 0
+                ? "Create your first notebook to get started"
+                : "Try a different search term"}
+            </p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {filtered.map((nb) => (
+              <div
+                key={nb.id}
+                onClick={() => navigate(`/notebooks/${nb.id}`)}
+                className="group cursor-pointer rounded-xl border border-border bg-surface p-4 transition hover:border-accent/50 hover:shadow-lg hover:shadow-accent/5"
+              >
+                {/* Cover */}
+                <div className="mb-3 flex h-24 items-center justify-center rounded-lg bg-surface-light">
+                  <BookOpen size={32} className="text-muted/30" />
+                </div>
+
+                {/* Title */}
+                <h3 className="mb-1 truncate font-medium text-text-strong group-hover:text-accent transition">
+                  {nb.title}
+                </h3>
+
+                {/* Description */}
+                {nb.description && (
+                  <p className="mb-2 line-clamp-2 text-xs text-muted">
+                    {nb.description}
+                  </p>
+                )}
+
+                {/* Meta */}
+                <div className="flex items-center gap-3 text-xs text-muted">
+                  <span className="flex items-center gap-1">
+                    <FileText size={12} />
+                    {nb.source_count} sources
+                  </span>
+                  <span className="flex items-center gap-1">
+                    <Clock size={12} />
+                    {new Date(nb.updated_at).toLocaleDateString()}
+                  </span>
+                </div>
+
+                {/* Delete */}
+                <button
+                  onClick={(e) => handleDelete(e, nb.id)}
+                  className="absolute right-3 top-3 rounded p-1 text-muted opacity-0 hover:bg-red-600/20 hover:text-red-400 group-hover:opacity-100 transition-opacity"
+                >
+                  <Trash2 size={14} />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/tests/notebook.spec.ts
+++ b/tests/notebook.spec.ts
@@ -1,0 +1,159 @@
+import { test, expect } from "@playwright/test";
+
+const AUTH_TOKEN = process.env.AUTH_TOKEN || "test-token-123";
+const BASE = "http://localhost:5174";
+
+async function login(page: import("@playwright/test").Page) {
+  await page.goto(`${BASE}/login`, { waitUntil: "networkidle" });
+  await page.locator("button", { hasText: "Auth Token" }).click();
+  await page.locator("[data-testid='token-input']").fill(AUTH_TOKEN);
+  await page.locator("[data-testid='login-button']").click();
+  await page.waitForURL("**/", { timeout: 15_000 });
+}
+
+test.describe("MoFa Notebook", () => {
+  test("sidebar shows Notebooks and Chat tabs", async ({ page }) => {
+    await login(page);
+    // Should see both nav tabs
+    await expect(page.locator("button", { hasText: "Notebooks" })).toBeVisible();
+    await expect(page.getByRole("complementary").getByRole("button", { name: "Chat", exact: true })).toBeVisible();
+  });
+
+  test("navigate to notebooks list page", async ({ page }) => {
+    await login(page);
+    await page.locator("button", { hasText: "Notebooks" }).click();
+    await page.waitForURL("**/notebooks", { timeout: 5_000 });
+
+    // Should see the header
+    await expect(page.locator("text=MoFa Notebook")).toBeVisible();
+    await expect(page.locator("text=New Notebook")).toBeVisible();
+  });
+
+  test("create a new notebook", async ({ page }) => {
+    await login(page);
+    await page.goto(`${BASE}/notebooks`, { waitUntil: "networkidle" });
+
+    // Click "New Notebook"
+    await page.locator("button", { hasText: "New Notebook" }).click();
+
+    // Fill title
+    const titleInput = page.locator("input[placeholder='Notebook title...']");
+    await expect(titleInput).toBeVisible();
+    await titleInput.fill("Test Notebook");
+
+    // Click Create
+    await page.locator("button", { hasText: "Create" }).last().click();
+
+    // Should navigate to notebook detail
+    await page.waitForURL("**/notebooks/*", { timeout: 5_000 });
+
+    // Should see the notebook title and tabs
+    await expect(page.locator("text=Test Notebook")).toBeVisible();
+    await expect(page.getByRole("main").getByRole("button", { name: "Sources" })).toBeVisible();
+    await expect(page.getByRole("main").getByRole("button", { name: "Chat" })).toBeVisible();
+    await expect(page.getByRole("main").getByRole("button", { name: "Notes" })).toBeVisible();
+    await expect(page.getByRole("main").getByRole("button", { name: "Studio" })).toBeVisible();
+  });
+
+  test("notebook detail tabs work", async ({ page }) => {
+    await login(page);
+    await page.goto(`${BASE}/notebooks`, { waitUntil: "networkidle" });
+
+    // Create a notebook first
+    await page.locator("button", { hasText: "New Notebook" }).click();
+    await page.locator("input[placeholder='Notebook title...']").fill("Tab Test");
+    await page.locator("button", { hasText: "Create" }).last().click();
+    await page.waitForURL("**/notebooks/*", { timeout: 5_000 });
+
+    // Click Sources tab
+    await page.locator("button", { hasText: "Sources" }).click();
+    await expect(page.locator("text=No sources yet")).toBeVisible();
+    await expect(page.locator("text=Add Source")).toBeVisible();
+
+    // Click Notes tab
+    await page.locator("button", { hasText: "Notes" }).click();
+    await expect(page.locator("text=No notes yet")).toBeVisible();
+
+    // Click Studio tab
+    await page.locator("button", { hasText: "Studio" }).click();
+    await expect(page.getByRole("heading", { name: "Studio" })).toBeVisible();
+    await expect(page.locator("text=Slides")).toBeVisible();
+    await expect(page.locator("text=Quiz")).toBeVisible();
+    await expect(page.locator("text=Flashcards")).toBeVisible();
+    await expect(page.locator("text=Mind Map")).toBeVisible();
+
+    // Click Chat tab (in the main area header)
+    await page.getByRole("main").getByRole("button", { name: "Chat" }).click();
+    await expect(page.locator("text=Chat with your sources")).toBeVisible();
+  });
+
+  test("navigate back to notebooks list", async ({ page }) => {
+    await login(page);
+    await page.goto(`${BASE}/notebooks`, { waitUntil: "networkidle" });
+
+    // Create notebook
+    await page.locator("button", { hasText: "New Notebook" }).click();
+    await page.locator("input[placeholder='Notebook title...']").fill("Back Nav Test");
+    await page.locator("button", { hasText: "Create" }).last().click();
+    await page.waitForURL("**/notebooks/*", { timeout: 5_000 });
+
+    // Click back arrow (first button in main header area)
+    await page.getByRole("main").locator("button").first().click();
+    await page.waitForURL("**/notebooks", { timeout: 10_000 });
+
+    // Should see the notebook in the list
+    await expect(page.locator("text=Back Nav Test")).toBeVisible();
+  });
+
+  test("notebook shows in list after creation", async ({ page }) => {
+    await login(page);
+    await page.goto(`${BASE}/notebooks`, { waitUntil: "networkidle" });
+
+    // Create two notebooks
+    for (const title of ["Physics 101", "Chemistry Lab"]) {
+      await page.locator("button", { hasText: "New Notebook" }).click();
+      await page.locator("input[placeholder='Notebook title...']").fill(title);
+      await page.locator("button", { hasText: "Create" }).last().click();
+      await page.waitForURL("**/notebooks/*", { timeout: 5_000 });
+      await page.goto(`${BASE}/notebooks`, { waitUntil: "networkidle" });
+    }
+
+    // Both should appear
+    await expect(page.locator("text=Physics 101")).toBeVisible();
+    await expect(page.locator("text=Chemistry Lab")).toBeVisible();
+  });
+
+  test("switch between Notebooks and Chat mode", async ({ page }) => {
+    await login(page);
+
+    // Start in Chat mode
+    await expect(page.locator("[data-testid='chat-input']")).toBeVisible();
+
+    // Switch to Notebooks
+    await page.locator("button", { hasText: "Notebooks" }).click();
+    await page.waitForURL("**/notebooks", { timeout: 5_000 });
+    await expect(page.locator("text=MoFa Notebook")).toBeVisible();
+
+    // Switch back to Chat
+    await page.getByRole("complementary").getByRole("button", { name: "Chat" }).click();
+    await page.waitForURL(/\/$/, { timeout: 5_000 });
+    await expect(page.locator("[data-testid='chat-input']")).toBeVisible();
+  });
+
+  test("studio panel shows all output types", async ({ page }) => {
+    await login(page);
+    await page.goto(`${BASE}/notebooks`, { waitUntil: "networkidle" });
+
+    await page.locator("button", { hasText: "New Notebook" }).click();
+    await page.locator("input[placeholder='Notebook title...']").fill("Studio Test");
+    await page.locator("button", { hasText: "Create" }).last().click();
+    await page.waitForURL("**/notebooks/*", { timeout: 5_000 });
+
+    await page.locator("button", { hasText: "Studio" }).click();
+
+    const expectedTypes = ["Slides", "Quiz", "Flashcards", "Mind Map", "Audio", "Infographic", "Comic", "Report", "Research"];
+    for (const t of expectedTypes) {
+      await expect(page.locator(`text=${t}`).first()).toBeVisible();
+    }
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,6 @@ export default defineConfig({
     proxy: {
       "/api": {
         target: "http://localhost:9326",
-        rewrite: (path: string) => path.replace(/^\/api/, ""),
       },
     },
   },


### PR DESCRIPTION
## Summary
- Notebook list page with create/delete/search
- Notebook detail page with Sources/Chat/Notes/Studio tabs
- Sidebar navigation: Notebooks ↔ Chat mode switching
- Studio panel showing 9 output types
- Playwright E2E tests (8 tests, all passing)

## Changes
- `src/notebook/` — new module with pages, API layer, types
- `src/App.tsx` — added `/notebooks` and `/notebooks/:id` routes
- `src/layouts/chat-layout.tsx` — sidebar Notebooks/Chat tabs
- `vite.config.ts` — fix proxy config
- `tests/notebook.spec.ts` — 8 E2E tests

## Test plan
- [x] `npx playwright test tests/notebook.spec.ts` — 8/8 passing
- [x] TypeScript compiles with zero errors

Closes #10 #11